### PR TITLE
Add trailing slash to local routes.

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -62,10 +62,10 @@ else window.onload = loadjs;
         <div id="main">
             <a href="/"><h1 id="title">i3 - improved tiling WM</h1></a>
 			<ul id="nav">
-{% include menulink.html name="Docs" url="/docs" %}
-{% include menulink.html name="Screens" url="/screenshots" %}
+{% include menulink.html name="Docs" url="/docs/" %}
+{% include menulink.html name="Screens" url="/screenshots/" %}
 {% include menulink.html name="FAQ" url="https://www.reddit.com/r/i3wm/" %}
-{% include menulink.html name="Contact" url="/contact" %}
+{% include menulink.html name="Contact" url="/contact/" %}
 {% include menulink.html name="Bugs" url="https://github.com/i3/i3/issues" %}
 			</ul>
 	<br style="clear: both">


### PR DESCRIPTION
Github pages sends a 301 for resources without a trailing slash, which rewrites HTTPS --> HTTP.

This patch should avoid that problem. I've sent an email to support@github, will keep you updated with the response.